### PR TITLE
[Snap 1008] Pause zeppelin scala interpreter when critical up event is triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ Snappydata interpreter for Apache Zeppelin
 [SnappyData](http://snappydatainc.github.io/snappydata/) is a distributed in-memory data store for real-time operational analytics, delivering stream analytics, OLTP (online transaction processing) and OLAP (online analytical processing) in a single integrated cluster. We realize this platform through a seamless integration of Apache Spark (as a big data computational engine) with GemFire XD (as an in-memory transactional store with scale-out SQL semantics).
 
 ## Installing and Running Snappydata Interpreter:
-Snappydata cluster internally starts zeppelin interpreter on the lead node so in order to use Snappydata interpreters in zeppelin, you have install Snappydata cluster using simple steps as mentioned in the following [here](<TODO: Add installation docs link here>):
-  Once snappydata cluster is being set up you have to connect to snappydata interpreter from zeppelin server.Following are the steps used to connect to remotely executing snappydata interpreter from zeppelin server:
-  1. Login to the zeppelin UI and browse for interpreter settings
-  2. Search for snappydata interpreter settings.Click edit the snappydata interpreter and then select "Connect to existing process"
-  3. Specify host on which snappydata lead node is executing along with the snappydata zeppelin port (Default: 3768) 
-  4. Edit the other properties if needed.Following image shows snappydata interpreter properties:
+In order to use zeppelin with SnappyData following are the steps that needs to be performed:
+1) Download latest snappydata binary and extract it
+2) Copy snappydata zeppelin interpreter jar in the jars directory of snappydata
+3) Enable snappydata zeppelin interpreter by setting **_zeppelin.interpreter.enable_** to true in lead node configuration
+4) Start SnappyData cluster
+Once snappydata cluster is being set up you have to connect to snappydata interpreter from zeppelin server.Following are the steps used to connect to remotely executing snappydata interpreter from zeppelin server:
+1) Login to the zeppelin UI and browse for interpreter settings
+2) Search for snappydata interpreter settings.Click edit the snappydata interpreter and then select "Connect to existing process"
+3) Specify host on which snappydata lead node is executing along with the snappydata zeppelin port (Default: 3768)
+4) Edit the other properties if needed.Following image shows snappydata interpreter properties:
   ![Snappydata Interpreter settings](images/snappydata_interpreter_properties.png)
 
 ## Supported properties and their values:

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     provided 'org.scala-lang:scala-compiler:' + scalaVersion
     provided "io.snappydata:snappy-spark-repl_" + scalaBinaryVersion + ":" + snappySparkVersion
     provided "io.snappydata:snappy-spark-core_" + scalaBinaryVersion + ":" + snappySparkVersion
+    //provided "io.snappydata:snappydata-cluster_" + scalaBinaryVersion + ":" + snappyDataVersion
+    compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
 }
 
 jar {
@@ -149,6 +151,8 @@ uploadArchives {
         compile 'org.scala-lang:scala-compiler:' + scalaVersion
         compile "io.snappydata:snappy-spark-repl_" + scalaBinaryVersion + ":" + snappySparkVersion
         compile "io.snappydata:snappy-spark-core_" + scalaBinaryVersion + ":" + snappySparkVersion
+       //compile "io.snappydata:snappydata-cluster_" + scalaBinaryVersion + ":" + snappyDataVersion
+        compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ ext {
     sparkVersion = '2.0.0'
     snappySparkVersion = '2.0.1-1'
     snappyDataVersion = '0.6-SNAPSHOT'
+    gemfireVersion = "1.5.1-SNAPSHOT"
 }
 
 configurations {
@@ -39,7 +40,8 @@ dependencies {
     provided "io.snappydata:snappy-spark-repl_" + scalaBinaryVersion + ":" + snappySparkVersion
     provided "io.snappydata:snappy-spark-core_" + scalaBinaryVersion + ":" + snappySparkVersion
     //provided "io.snappydata:snappydata-cluster_" + scalaBinaryVersion + ":" + snappyDataVersion
-    compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
+   // compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
+    compile "io.snappydata:gemfire-core:" + gemfireVersion
 }
 
 jar {
@@ -151,8 +153,11 @@ uploadArchives {
         compile 'org.scala-lang:scala-compiler:' + scalaVersion
         compile "io.snappydata:snappy-spark-repl_" + scalaBinaryVersion + ":" + snappySparkVersion
         compile "io.snappydata:snappy-spark-core_" + scalaBinaryVersion + ":" + snappySparkVersion
+        compile "io.snappydata:gemfire-core:" + gemfireVersion
+
+
        //compile "io.snappydata:snappydata-cluster_" + scalaBinaryVersion + ":" + snappyDataVersion
-        compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
+      //  compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
     }
 }
 

--- a/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.zeppelin.interpreter;
+
+import io.snappydata.gemxd.MemoryNotificationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MemoryListenerImpl implements MemoryNotificationListener {
+  public static Logger logger = LoggerFactory.getLogger(MemoryListenerImpl.class);
+  @Override
+  public void notifyCriticalUp() {
+
+    logger.warn("Critical Up memory event Occured");
+    SnappyDataZeppelinInterpreter.cancelAllJobsAndPause();
+  }
+
+  @Override
+  public void notifyEvictionUp() {
+
+  }
+}

--- a/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
@@ -16,21 +16,21 @@
  */
 package org.apache.zeppelin.interpreter;
 
-import io.snappydata.gemxd.MemoryNotificationListener;
+import com.gemstone.gemfire.internal.cache.control.MemoryEvent;
+import com.gemstone.gemfire.internal.cache.control.ResourceListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MemoryListenerImpl implements MemoryNotificationListener {
+public class MemoryListenerImpl implements ResourceListener<MemoryEvent> {
   public static Logger logger = LoggerFactory.getLogger(MemoryListenerImpl.class);
+
   @Override
-  public void notifyCriticalUp() {
+  public void onEvent(MemoryEvent event) {
 
     logger.warn("Critical Up memory event Occured");
-    SnappyDataZeppelinInterpreter.cancelAllJobsAndPause();
-  }
 
-  @Override
-  public void notifyEvictionUp() {
-
+    if (event.getState().isCritical()) {
+      SnappyDataZeppelinInterpreter.cancelAllJobsAndPause();
+    }
   }
 }

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataSqlZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataSqlZeppelinInterpreter.java
@@ -105,21 +105,8 @@ public class SnappyDataSqlZeppelinInterpreter extends JDBCInterpreter {
         for (InterpreterContextRunner r : contextInterpreter.getRunners()) {
           if (id.equals(r.getParagraphId())) {
 
-            String query = queries[queries.length - 1]+" with error";
+            String query = queries[queries.length - 1] + " with error";
             final InterpreterResult res = executeSql(propertyKey, query, contextInterpreter);
-
-            try{
-              /*Adding a delay of few milliseconds in order for zeppelin to render
-               the result.As this delay is after the query execution it will not
-               be considered in query time. This delay is basically the gap between
-               first query and spawning of the next query.
-              */
-              Thread.sleep(200);
-            } catch (InterruptedException interruptedException) {
-
-              //Ignore this exception as this should not harm the behaviour
-            }
-
             exService.submit(new QueryExecutor(r));
             return res;
           }
@@ -272,6 +259,17 @@ public class SnappyDataSqlZeppelinInterpreter extends JDBCInterpreter {
     @Override
     public Integer call() throws Exception {
 
+      try {
+              /*Adding a delay of few milliseconds in order for zeppelin to render
+               the result.As this delay is after the query execution it will not
+               be considered in query time. This delay is basically the gap between
+               first query and spawning of the next query.
+              */
+        Thread.sleep(200);
+      } catch (InterruptedException interruptedException) {
+
+        //Ignore this exception as this should not harm the behaviour
+      }
       runner.run();
 
       return 0;

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -37,6 +37,7 @@ package org.apache.zeppelin.interpreter;
 
 
 //import io.snappydata.gemxd.LeadNodeMemoryListener;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -206,7 +207,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
         return null;
       }
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
-        | IllegalArgumentException | InvocationTargetException e) {
+            | IllegalArgumentException | InvocationTargetException e) {
       logger.error(e.toString(), e);
       return null;
     }
@@ -237,11 +238,11 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   public SparkDependencyResolver getDependencyResolver() {
     if (dep == null) {
       dep = new SparkDependencyResolver(
-          (Global)ZeppelinIntpUtil.invokeMethod(intp, "global"),
-          (ClassLoader)ZeppelinIntpUtil.invokeMethod(ZeppelinIntpUtil.invokeMethod(intp, "classLoader"), "getParent"),
-          sc,
-          getProperty("zeppelin.dep.localrepo"),
-          getProperty("zeppelin.dep.additionalRemoteRepository"));
+              (Global) ZeppelinIntpUtil.invokeMethod(intp, "global"),
+              (ClassLoader) ZeppelinIntpUtil.invokeMethod(ZeppelinIntpUtil.invokeMethod(intp, "classLoader"), "getParent"),
+              sc,
+              getProperty("zeppelin.dep.localrepo"),
+              getProperty("zeppelin.dep.additionalRemoteRepository"));
     }
     return dep;
   }
@@ -279,7 +280,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
       Properties intpProperty = getProperty();
 
       for (Object k : intpProperty.keySet()) {
-        String key = (String)k;
+        String key = (String) k;
         String val = toString(intpProperty.get(key));
         if (!key.startsWith("spark.") || !val.trim().isEmpty()) {
           logger.debug(String.format("SparkConf: key = [%s], value = [%s]", key, val));
@@ -306,7 +307,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
 
   static final String toString(Object o) {
-    return (o instanceof String) ? (String)o : "";
+    return (o instanceof String) ? (String) o : "";
   }
 
 
@@ -317,7 +318,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
       System.setProperty("SPARK_YARN_MODE", "true");
     }
     if (getProperty().containsKey("spark.yarn.keytab") &&
-        getProperty().containsKey("spark.yarn.principal")) {
+            getProperty().containsKey("spark.yarn.principal")) {
       try {
         String keytab = getProperty().getProperty("spark.yarn.keytab");
         String principal = getProperty().getProperty("spark.yarn.principal");
@@ -373,7 +374,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
 
     scala.collection.immutable.List<String> list =
-        JavaConversions.asScalaBuffer(argList).toList();
+            JavaConversions.asScalaBuffer(argList).toList();
 
     settings.processArguments(list, true);
 
@@ -421,8 +422,8 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
     // set classloader for scala compiler
     settings.explicitParentLoader_$eq(new Some<ClassLoader>(Thread.currentThread()
-        .getContextClassLoader()));
-    BooleanSetting b = (BooleanSetting)settings.usejavacp();
+            .getContextClassLoader()));
+    BooleanSetting b = (BooleanSetting) settings.usejavacp();
     b.v_$eq(true);
     settings.scala$tools$nsc$settings$StandardScalaSettings$_setter_$usejavacp_$eq(b);
 
@@ -444,12 +445,12 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
     MutableSettings.IntSetting numClassFileSetting = settings.maxClassfileName();
     numClassFileSetting.v_$eq(128);
     settings.scala$tools$nsc$settings$ScalaSettings$_setter_$maxClassfileName_$eq(
-        numClassFileSetting);
+            numClassFileSetting);
 
     synchronized (sharedInterpreterLock) {
       /* create scala repl */
 
-      this.interpreter = new SparkILoop((java.io.BufferedReader)null, new PrintWriter(out));
+      this.interpreter = new SparkILoop((java.io.BufferedReader) null, new PrintWriter(out));
 
       interpreter.settings_$eq(settings);
 
@@ -462,21 +463,21 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
       if (ZeppelinIntpUtil.findClass("org.apache.spark.repl.SparkJLineCompletion", true) != null) {
         completer = ZeppelinIntpUtil.instantiateClass(
-            "org.apache.spark.repl.SparkJLineCompletion",
-            new Class[]{ZeppelinIntpUtil.findClass("org.apache.spark.repl.SparkIMain")},
-            new Object[]{intp});
+                "org.apache.spark.repl.SparkJLineCompletion",
+                new Class[]{ZeppelinIntpUtil.findClass("org.apache.spark.repl.SparkIMain")},
+                new Object[]{intp});
       } else if (ZeppelinIntpUtil.findClass(
-          "scala.tools.nsc.interpreter.PresentationCompilerCompleter", true) != null) {
+              "scala.tools.nsc.interpreter.PresentationCompilerCompleter", true) != null) {
         completer = ZeppelinIntpUtil.instantiateClass(
-            "scala.tools.nsc.interpreter.PresentationCompilerCompleter",
-            new Class[]{IMain.class},
-            new Object[]{intp});
+                "scala.tools.nsc.interpreter.PresentationCompilerCompleter",
+                new Class[]{IMain.class},
+                new Object[]{intp});
       } else if (ZeppelinIntpUtil.findClass(
-          "scala.tools.nsc.interpreter.JLineCompletion", true) != null) {
+              "scala.tools.nsc.interpreter.JLineCompletion", true) != null) {
         completer = ZeppelinIntpUtil.instantiateClass(
-            "scala.tools.nsc.interpreter.JLineCompletion",
-            new Class[]{IMain.class},
-            new Object[]{intp});
+                "scala.tools.nsc.interpreter.JLineCompletion",
+                new Class[]{IMain.class},
+                new Object[]{intp});
       }
       sparkSession = getSparkSession();
       sc = getSparkContext();
@@ -495,12 +496,12 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
       dep = getDependencyResolver();
 
       z = new ZeppelinContext(sc, snc, null, dep,
-          Integer.parseInt(getProperty("zeppelin.spark.maxResult")));
+              Integer.parseInt(getProperty("zeppelin.spark.maxResult")));
 
       interpret("@transient val _binder = new java.util.HashMap[String, Object]()");
       Map<String, Object> binder;
 
-      binder = (Map<String, Object>)getLastObject();
+      binder = (Map<String, Object>) getLastObject();
       binder.put("sc", sc);
       binder.put("snc", snc);
       binder.put("z", z);
@@ -509,17 +510,17 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
 
       interpret("@transient val z = "
-          + "_binder.get(\"z\").asInstanceOf[org.apache.zeppelin.spark.ZeppelinContext]");
+              + "_binder.get(\"z\").asInstanceOf[org.apache.zeppelin.spark.ZeppelinContext]");
       interpret("@transient val sc = "
-          + "_binder.get(\"sc\").asInstanceOf[org.apache.spark.SparkContext]");
+              + "_binder.get(\"sc\").asInstanceOf[org.apache.spark.SparkContext]");
       // Injecting SnappyContext in repl
       interpret("@transient val snc = "
-          + "_binder.get(\"snc\").asInstanceOf[org.apache.spark.sql.SnappyContext]");
+              + "_binder.get(\"snc\").asInstanceOf[org.apache.spark.sql.SnappyContext]");
       interpret("@transient val snappyContext = "
-          + "_binder.get(\"snc\").asInstanceOf[org.apache.spark.sql.SnappyContext]");
+              + "_binder.get(\"snc\").asInstanceOf[org.apache.spark.sql.SnappyContext]");
 
       interpret("@transient val spark = "
-          + "_binder.get(\"spark\").asInstanceOf[org.apache.spark.sql.SparkSession]");
+              + "_binder.get(\"spark\").asInstanceOf[org.apache.spark.sql.SparkSession]");
 
       interpret("import org.apache.spark.SparkContext._");
       interpret("import org.apache.spark.sql.SnappyContext._");
@@ -566,11 +567,11 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   }
 
   private Results.Result interpret(String line) {
-    return (Results.Result)ZeppelinIntpUtil.invokeMethod(
-        intp,
-        "interpret",
-        new Class[]{String.class},
-        new Object[]{line});
+    return (Results.Result) ZeppelinIntpUtil.invokeMethod(
+            intp,
+            "interpret",
+            new Class[]{String.class},
+            new Object[]{line});
   }
 
   private List<File> currentClassPath() {
@@ -591,7 +592,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
     }
 
     if (cl instanceof URLClassLoader) {
-      URLClassLoader ucl = (URLClassLoader)cl;
+      URLClassLoader ucl = (URLClassLoader) cl;
       URL[] urls = ucl.getURLs();
       if (urls != null) {
         for (URL url : urls) {
@@ -618,7 +619,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
       cursor = completionText.length();
     }
 
-    ScalaCompleter c = (ScalaCompleter)ZeppelinIntpUtil.invokeMethod(completer, "completer");
+    ScalaCompleter c = (ScalaCompleter) ZeppelinIntpUtil.invokeMethod(completer, "completer");
     Candidates ret = c.complete(completionText, cursor);
 
     List<String> candidates = WrapAsJava$.MODULE$.seqAsJavaList(ret.candidates());
@@ -664,19 +665,19 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
       completionStartPosition = completionEndPosition - completionStartPosition;
     }
     resultCompletionText = completionScriptText.substring(
-        completionStartPosition, completionEndPosition);
+            completionStartPosition, completionEndPosition);
 
     return resultCompletionText;
   }
 
 
   public Object getLastObject() {
-    IMain.Request r = (IMain.Request)ZeppelinIntpUtil.invokeMethod(intp, "lastRequest");
+    IMain.Request r = (IMain.Request) ZeppelinIntpUtil.invokeMethod(intp, "lastRequest");
     if (r == null || r.lineRep() == null) {
       return null;
     }
     Object obj = r.lineRep().call("$result",
-        JavaConversions.asScalaBuffer(new LinkedList<Object>()));
+            JavaConversions.asScalaBuffer(new LinkedList<Object>()));
     return obj;
   }
 
@@ -690,10 +691,10 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String line, InterpreterContext context) {
 
-    if(!pauseInterpreter) {
+    if (!pauseInterpreter) {
       if (sparkVersion.isUnsupportedVersion()) {
         return new InterpreterResult(Code.ERROR, "Spark " + sparkVersion.toString()
-            + " is not supported");
+                + " is not supported");
       }
 
       z.setInterpreterContext(context);
@@ -703,7 +704,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
       return interpret(line.split("\n"), context);
     } else {
       return new InterpreterResult(Code.INCOMPLETE,
-          "Memory threshold reached.Please restart interpreter to release memory");
+              "Memory threshold reached.Please restart interpreter to release memory");
     }
   }
 
@@ -742,9 +743,9 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
         String nextLine = linesToRun[l + 1].trim();
         boolean continuation = false;
         if (nextLine.isEmpty()
-            || nextLine.startsWith("//")         // skip empty line or comment
-            || nextLine.startsWith("}")
-            || nextLine.startsWith("object")) {  // include "} object" for Scala companion object
+                || nextLine.startsWith("//")         // skip empty line or comment
+                || nextLine.startsWith("}")
+                || nextLine.startsWith("object")) {  // include "} object" for Scala companion object
           continuation = true;
         } else if (!inComment && nextLine.startsWith("/*")) {
           inComment = true;
@@ -753,9 +754,9 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
           inComment = false;
           continuation = true;
         } else if (nextLine.length() > 1
-            && nextLine.charAt(0) == '.'
-            && nextLine.charAt(1) != '.'     // ".."
-            && nextLine.charAt(1) != '/') {  // "./"
+                && nextLine.charAt(0) == '.'
+                && nextLine.charAt(1) != '.'     // ".."
+                && nextLine.charAt(1) != '/') {  // "./"
           continuation = true;
         } else if (inComment) {
           continuation = true;
@@ -829,7 +830,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
     Iterator<ActiveJob> it = jobs.iterator();
     while (it.hasNext()) {
       ActiveJob job = it.next();
-      String g = (String)job.properties().get("spark.jobGroup.id");
+      String g = (String) job.properties().get("spark.jobGroup.id");
       if (jobGroup.equals(g)) {
         int[] progressInfo = null;
         try {
@@ -840,8 +841,8 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
             progressInfo = getProgressFromStage_1_1x(sparkListener, finalStage);
           }
         } catch (IllegalAccessException | IllegalArgumentException
-            | InvocationTargetException | NoSuchMethodException
-            | SecurityException e) {
+                | InvocationTargetException | NoSuchMethodException
+                | SecurityException e) {
           logger.error("Can't get progress info", e);
           return 0;
         }
@@ -858,24 +859,24 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
 
   private int[] getProgressFromStage_1_0x(JobProgressListener sparkListener, Object stage)
-      throws IllegalAccessException, IllegalArgumentException,
-      InvocationTargetException, NoSuchMethodException, SecurityException {
-    int numTasks = (int)stage.getClass().getMethod("numTasks").invoke(stage);
+          throws IllegalAccessException, IllegalArgumentException,
+          InvocationTargetException, NoSuchMethodException, SecurityException {
+    int numTasks = (int) stage.getClass().getMethod("numTasks").invoke(stage);
     int completedTasks = 0;
 
-    int id = (int)stage.getClass().getMethod("id").invoke(stage);
+    int id = (int) stage.getClass().getMethod("id").invoke(stage);
 
     Object completedTaskInfo = null;
 
     completedTaskInfo = JavaConversions.mapAsJavaMap(
-        (HashMap<Object, Object>)sparkListener.getClass()
-            .getMethod("stageIdToTasksComplete").invoke(sparkListener)).get(id);
+            (HashMap<Object, Object>) sparkListener.getClass()
+                    .getMethod("stageIdToTasksComplete").invoke(sparkListener)).get(id);
 
     if (completedTaskInfo != null) {
-      completedTasks += (int)completedTaskInfo;
+      completedTasks += (int) completedTaskInfo;
     }
-    List<Object> parents = JavaConversions.seqAsJavaList((Seq<Object>)stage.getClass()
-        .getMethod("parents").invoke(stage));
+    List<Object> parents = JavaConversions.seqAsJavaList((Seq<Object>) stage.getClass()
+            .getMethod("parents").invoke(stage));
     if (parents != null) {
       for (Object s : parents) {
         int[] p = getProgressFromStage_1_0x(sparkListener, s);
@@ -888,34 +889,34 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   }
 
   private int[] getProgressFromStage_1_1x(JobProgressListener sparkListener, Object stage)
-      throws IllegalAccessException, IllegalArgumentException,
-      InvocationTargetException, NoSuchMethodException, SecurityException {
-    int numTasks = (int)stage.getClass().getMethod("numTasks").invoke(stage);
+          throws IllegalAccessException, IllegalArgumentException,
+          InvocationTargetException, NoSuchMethodException, SecurityException {
+    int numTasks = (int) stage.getClass().getMethod("numTasks").invoke(stage);
     int completedTasks = 0;
-    int id = (int)stage.getClass().getMethod("id").invoke(stage);
+    int id = (int) stage.getClass().getMethod("id").invoke(stage);
 
     try {
       Method stageIdToData = sparkListener.getClass().getMethod("stageIdToData");
       HashMap<Tuple2<Object, Object>, Object> stageIdData =
-          (HashMap<Tuple2<Object, Object>, Object>)stageIdToData.invoke(sparkListener);
+              (HashMap<Tuple2<Object, Object>, Object>) stageIdToData.invoke(sparkListener);
       Class<?> stageUIDataClass =
-          this.getClass().forName("org.apache.spark.ui.jobs.UIData$StageUIData");
+              this.getClass().forName("org.apache.spark.ui.jobs.UIData$StageUIData");
 
       Method numCompletedTasks = stageUIDataClass.getMethod("numCompleteTasks");
       Set<Tuple2<Object, Object>> keys =
-          JavaConverters.setAsJavaSetConverter(stageIdData.keySet()).asJava();
+              JavaConverters.setAsJavaSetConverter(stageIdData.keySet()).asJava();
       for (Tuple2<Object, Object> k : keys) {
-        if (id == (int)k._1()) {
+        if (id == (int) k._1()) {
           Object uiData = stageIdData.get(k).get();
-          completedTasks += (int)numCompletedTasks.invoke(uiData);
+          completedTasks += (int) numCompletedTasks.invoke(uiData);
         }
       }
     } catch (Exception e) {
       logger.error("Error on getting progress information", e);
     }
 
-    List<Object> parents = JavaConversions.seqAsJavaList((Seq<Object>)stage.getClass()
-        .getMethod("parents").invoke(stage));
+    List<Object> parents = JavaConversions.seqAsJavaList((Seq<Object>) stage.getClass()
+            .getMethod("parents").invoke(stage));
     if (parents != null) {
       for (Object s : parents) {
         int[] p = getProgressFromStage_1_1x(sparkListener, s);
@@ -953,7 +954,7 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   @Override
   public Scheduler getScheduler() {
     return SchedulerFactory.singleton().createOrGetParallelScheduler(
-        SnappyDataZeppelinInterpreter.class.getName() + this.hashCode(), 10);
+            SnappyDataZeppelinInterpreter.class.getName() + this.hashCode(), 10);
   }
 
   public ZeppelinContext getZeppelinContext() {

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -36,8 +36,6 @@
 package org.apache.zeppelin.interpreter;
 
 
-//import io.snappydata.gemxd.LeadNodeMemoryListener;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -53,7 +51,6 @@ import java.util.Map;
 
 import com.google.common.base.Joiner;
 
-import io.snappydata.gemxd.MemoryNotificationFactory;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -146,7 +143,6 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   public SnappyDataZeppelinInterpreter(Properties property) {
     super(property);
     out = new SparkOutputStream(logger);
-    MemoryNotificationFactory.attachListener(new MemoryListenerImpl());
   }
 
   public SnappyDataZeppelinInterpreter(Properties property, SparkContext sc) {
@@ -155,7 +151,6 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
     this.sc = sc;
     env = SparkEnv.get();
     sparkListener = setupListeners(this.sc);
-    MemoryNotificationFactory.attachListener(new MemoryListenerImpl());
   }
 
   public SparkContext getSparkContext() {

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyInterpreterServer.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyInterpreterServer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.zeppelin.interpreter;
 
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.internal.cache.control.InternalResourceManager;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer;
@@ -31,6 +33,10 @@ public class SnappyInterpreterServer extends RemoteInterpreterServer {
   public SnappyInterpreterServer(Integer port) throws TTransportException {
     super(port);
     logger.info("Initializing SnappyInterpreter Server");
+
+    GemFireCacheImpl.getInstance().getResourceManager().
+            addResourceListener(InternalResourceManager.ResourceType.ALL, new MemoryListenerImpl());
+
   }
 
   /**

--- a/src/main/java/org/apache/zeppelin/interpreter/ZeppelinIntpUtil.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/ZeppelinIntpUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 package org.apache.zeppelin.interpreter;
 
 import org.apache.spark.util.Utils;
@@ -69,10 +85,10 @@ public class ZeppelinIntpUtil {
   static Object instantiateClass(String name, Class[] argTypes, Object[] params) {
     try {
       Constructor<?> constructor = ZeppelinIntpUtil.class.getClassLoader()
-          .loadClass(name).getConstructor(argTypes);
+              .loadClass(name).getConstructor(argTypes);
       return constructor.newInstance(params);
     } catch (NoSuchMethodException | ClassNotFoundException | IllegalAccessException |
-        InstantiationException | InvocationTargetException e) {
+            InstantiationException | InvocationTargetException e) {
       logger.error(e.getMessage(), e);
     }
     return null;


### PR DESCRIPTION
## Changes proposed in this pull request
-  SNAP-1008 used to monitor memory of lead node which is used to pause zeppelin interpreter
## Patch testing

Tested manually
## ReleaseNotes.txt changes

No
## Other PRs

N/A
