### PR TITLE
[SNAP-1029] Zeppelin interpreter should set properties related to s3 storage in the spark hadoop configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     compile group: 'org.apache.zeppelin', name: 'zeppelin-interpreter', version: '0.6.1'
     compile group: 'org.apache.zeppelin', name: 'zeppelin-spark_2.11', version: '0.6.1'
     compile group: 'org.apache.zeppelin', name: 'zeppelin-jdbc', version: '0.6.1'
+    compile group: 'org.apache.hadoop', name: 'hadoop-aws', version: '2.7.3'
+    compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.7.4'
     provided "io.snappydata:snappydata-core_" + scalaBinaryVersion + ":" + snappyDataVersion
     provided "org.scala-lang:scala-library:" + scalaVersion
     provided 'org.scala-lang:scala-reflect:' + scalaVersion
@@ -154,6 +156,8 @@ uploadArchives {
         compile "io.snappydata:snappy-spark-repl_" + scalaBinaryVersion + ":" + snappySparkVersion
         compile "io.snappydata:snappy-spark-core_" + scalaBinaryVersion + ":" + snappySparkVersion
         compile "io.snappydata:gemfire-core:" + gemfireVersion
+        compile group: 'org.apache.hadoop', name: 'hadoop-aws', version: '2.7.3'
+        compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.7.4'
 
 
        //compile "io.snappydata:snappydata-cluster_" + scalaBinaryVersion + ":" + snappyDataVersion

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'wrapper'
 apply plugin: 'maven-publish'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'distribution'
 
 
 repositories {
@@ -13,6 +14,14 @@ repositories {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     maven { url "https://oss.sonatype.org/content/repositories/public" }
 }
+
+gradle.taskGraph.whenReady( { graph ->
+    tasks.withType(Tar).each { tar ->
+        tar.compression = Compression.GZIP
+        tar.extension = 'tar.gz'
+    }
+})
+
 ext {
     scalaBinaryVersion = '2.11'
     scalaVersion = scalaBinaryVersion + '.8'
@@ -42,7 +51,6 @@ dependencies {
     provided "io.snappydata:snappy-spark-repl_" + scalaBinaryVersion + ":" + snappySparkVersion
     provided "io.snappydata:snappy-spark-core_" + scalaBinaryVersion + ":" + snappySparkVersion
     //provided "io.snappydata:snappydata-cluster_" + scalaBinaryVersion + ":" + snappyDataVersion
-   // compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
     compile "io.snappydata:gemfire-core:" + gemfireVersion
 }
 
@@ -61,9 +69,41 @@ jar {
     }
 }
 
-/*signing {
-    sign configurations.archives
-}*/
+task packageSources(type: Jar, dependsOn: classes) {
+    if (rootProject.hasProperty('enablePublish')) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+}
+task packageDocs(type: Jar, dependsOn: javadoc) {
+    if (rootProject.hasProperty('enablePublish')) {
+        classifier = 'javadoc'
+        from javadoc
+    }
+}
+
+artifacts {
+    archives packageSources, packageDocs
+}
+
+distributions {
+    main {
+        baseName = 'snappydata-zeppelin'
+        contents {
+            from "${rootProject.buildDir}/libs/"
+            from "src/main/resources/interpreter-setting.json"
+            from "src/main/resources/ansi.sql.keywords"
+        }
+    }
+}
+
+
+distTar {
+    dependsOn ':jar'
+    classifier 'bin'
+}
+
+
 
 /*
 //Used to generate and load maven artifacts
@@ -91,27 +131,25 @@ publishing {
 }
 */
 
-task packageSources(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-task packageDocs(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc
-}
+
 
 uploadArchives {
+    if (rootProject.hasProperty('enablePublish')) {
+        signing {
+            sign configurations.archives
+        }
+    }
     repositories {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-            //repository(url: "file://localhost/tmp/myRepo/")
-            repository(url: "file://localhost/home/sachin/.m2/repository")
-           /* repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+
+            //repository(url: "file://localhost/home/sachin/.m2/repository")
+            repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }
             snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
-            }*/
+            }
             pom.project {
                 name 'SnappyData'
                 packaging 'jar'
@@ -158,11 +196,17 @@ uploadArchives {
         compile "io.snappydata:gemfire-core:" + gemfireVersion
         compile group: 'org.apache.hadoop', name: 'hadoop-aws', version: '2.7.3'
         compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.7.4'
-
-
        //compile "io.snappydata:snappydata-cluster_" + scalaBinaryVersion + ":" + snappyDataVersion
-      //  compile files('/home/sachin/github/zeppelin/snappydata/build-artifacts/scala-2.11/snappy/jars/snappydata-cluster_2.11-0.6-SNAPSHOT.jar')
     }
+}
+
+task publishLocal {
+    dependsOn ':install'
+}
+
+
+task publishMaven {
+    dependsOn ':uploadArchives'
 }
 
 def installer = install.repositories.mavenInstaller

--- a/src/main/java/org/apache/zeppelin/interpreter/ParagraphState.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/ParagraphState.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.zeppelin.interpreter;
+
+
+public class ParagraphState {
+  boolean executeApproxQuery;
+  long timeRequiredForApproxQuery;
+  long timeRequiredForBaseQuery;
+
+  public boolean isExecuteApproxQuery() {
+    return executeApproxQuery;
+  }
+
+  public void setExecuteApproxQuery(boolean executeApproxQuery) {
+    this.executeApproxQuery = executeApproxQuery;
+  }
+
+  public long getTimeRequiredForApproxQuery() {
+    return timeRequiredForApproxQuery;
+  }
+
+  public void setTimeRequiredForApproxQuery(long timeRequiredForApproxQuery) {
+    this.timeRequiredForApproxQuery = timeRequiredForApproxQuery;
+  }
+
+  public long getTimeRequiredForBaseQuery() {
+    return timeRequiredForBaseQuery;
+  }
+
+  public void setTimeRequiredForBaseQuery(long timeRequiredForBaseQuery) {
+    this.timeRequiredForBaseQuery = timeRequiredForBaseQuery;
+  }
+}

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -127,6 +127,8 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   private static Integer sharedInterpreterLock = new Integer(0);
 
 
+  public static final String FS_S3A_ACCESS_KEY = "fs.s3a.access.key";
+  public static final String FS_S3A_SECRET_KEY = "fs.s3a.secret.key";
   private SparkOutputStream out;
   private SparkDependencyResolver dep;
 
@@ -484,6 +486,11 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
         sc.taskScheduler().rootPool().addSchedulable(pool);
       }
 
+      if (null != getProperty(FS_S3A_ACCESS_KEY) && null != getProperty(FS_S3A_SECRET_KEY)) {
+
+        sc.hadoopConfiguration().set(FS_S3A_ACCESS_KEY, getProperty(FS_S3A_ACCESS_KEY));
+        sc.hadoopConfiguration().set(FS_S3A_SECRET_KEY, getProperty(FS_S3A_SECRET_KEY));
+      }
       sparkVersion = SparkVersion.fromVersionString(sc.version());
 
       snc = getSnappyContext();

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -111,6 +111,7 @@ import org.apache.zeppelin.interpreter.Interpreter.FormType;
  * https://github.com/apache/zeppelin/blob/master/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
  */
 public class SnappyDataZeppelinInterpreter extends Interpreter {
+  public static final String FS_S3A_IMPL = "fs.s3a.impl";
   public static Logger logger = LoggerFactory.getLogger(SnappyDataZeppelinInterpreter.class);
   private ZeppelinContext z;
   private SparkILoop interpreter;
@@ -488,6 +489,8 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
       if (null != getProperty(FS_S3A_ACCESS_KEY) && null != getProperty(FS_S3A_SECRET_KEY)) {
 
+        logger.info("Setting s3 conf");
+        sc.hadoopConfiguration().set(FS_S3A_IMPL, "org.apache.hadoop.fs.s3a.S3AFileSystem");
         sc.hadoopConfiguration().set(FS_S3A_ACCESS_KEY, getProperty(FS_S3A_ACCESS_KEY));
         sc.hadoopConfiguration().set(FS_S3A_SECRET_KEY, getProperty(FS_S3A_SECRET_KEY));
       }


### PR DESCRIPTION
## Changes proposed in this pull request
- Changes related to loading of properties of s3 and applying it to spark hadoop configuration
- Changes related to show proper time for approx and base query in case of show-approx-results-first directive
## Patch testing
- Tested Manually
## ReleaseNotes.txt changes

No
## Other PRs

N/A
