### PR TITLE
[SNAP-1121] Changes related to connection pooling and setting some de…

### DIFF
--- a/src/main/java/org/apache/zeppelin/interpreter/Constants.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/Constants.java
@@ -1,0 +1,24 @@
+package org.apache.zeppelin.interpreter;
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+public class Constants {
+
+  public static final String FS_S3A_ACCESS_KEY = "fs.s3a.access.key";
+  public static final String FS_S3A_SECRET_KEY = "fs.s3a.secret.key";
+  public static final String FS_S3A_IMPL = "fs.s3a.impl";
+  public static final String SPARK_SQL_SHUFFLE_PARTITIONS = "spark.sql.shuffle.partitions";
+}

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -111,7 +111,6 @@ import org.apache.zeppelin.interpreter.Interpreter.FormType;
  * https://github.com/apache/zeppelin/blob/master/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
  */
 public class SnappyDataZeppelinInterpreter extends Interpreter {
-  public static final String FS_S3A_IMPL = "fs.s3a.impl";
   public static Logger logger = LoggerFactory.getLogger(SnappyDataZeppelinInterpreter.class);
   private ZeppelinContext z;
   private SparkILoop interpreter;
@@ -127,9 +126,6 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   private static JobProgressListener sparkListener;
   private static Integer sharedInterpreterLock = new Integer(0);
 
-
-  public static final String FS_S3A_ACCESS_KEY = "fs.s3a.access.key";
-  public static final String FS_S3A_SECRET_KEY = "fs.s3a.secret.key";
   private SparkOutputStream out;
   private SparkDependencyResolver dep;
 
@@ -487,12 +483,10 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
         sc.taskScheduler().rootPool().addSchedulable(pool);
       }
 
-      if (null != getProperty(FS_S3A_ACCESS_KEY) && null != getProperty(FS_S3A_SECRET_KEY)) {
-
-        logger.info("Setting s3 conf");
-        sc.hadoopConfiguration().set(FS_S3A_IMPL, "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        sc.hadoopConfiguration().set(FS_S3A_ACCESS_KEY, getProperty(FS_S3A_ACCESS_KEY));
-        sc.hadoopConfiguration().set(FS_S3A_SECRET_KEY, getProperty(FS_S3A_SECRET_KEY));
+      if (null != getProperty(Constants.FS_S3A_ACCESS_KEY) && null != getProperty(Constants.FS_S3A_SECRET_KEY)) {
+        sc.hadoopConfiguration().set(Constants.FS_S3A_IMPL, "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        sc.hadoopConfiguration().set(Constants.FS_S3A_ACCESS_KEY, getProperty(Constants.FS_S3A_ACCESS_KEY));
+        sc.hadoopConfiguration().set(Constants.FS_S3A_SECRET_KEY, getProperty(Constants.FS_S3A_SECRET_KEY));
       }
       sparkVersion = SparkVersion.fromVersionString(sc.version());
 

--- a/src/main/resources/interpreter-setting.json
+++ b/src/main/resources/interpreter-setting.json
@@ -1,7 +1,7 @@
 [
   {
     "group": "snappydata",
-    "name": "snappydata",
+    "name": "spark",
     "className": "org.apache.zeppelin.interpreter.SnappyDataZeppelinInterpreter",
     "properties": {
       "zeppelin.spark.printREPLOutput": {
@@ -76,7 +76,13 @@
         "propertyName": "zeppelin.jdbc.concurrent.use",
         "defaultValue": "true",
         "description": "Use parallel scheduler"
-     }
+     },
+      "spark.sql.shuffle.partitions": {
+        "envName": null,
+        "propertyName": "spark.sql.shuffle.partitions",
+        "defaultValue": "7",
+        "description": "Use parallel scheduler"
+      }
     }
   }
 ]


### PR DESCRIPTION
## Changes proposed in this pull request
- Reuse snappycontext for paragraph
- Change name of snappydata scala interpreter to spark
- Set default property spark.sql.shuffle.partitions
## Patch testing
- Manually tested 
## Other PRs

No

…fault properties
