### PR TITLE
[SNAP-1126] Fix for SNAP-1126 to set default max s3 connections to 10…

### DIFF
--- a/src/main/java/org/apache/zeppelin/interpreter/Constants.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/Constants.java
@@ -21,4 +21,5 @@ public class Constants {
   public static final String FS_S3A_SECRET_KEY = "fs.s3a.secret.key";
   public static final String FS_S3A_IMPL = "fs.s3a.impl";
   public static final String SPARK_SQL_SHUFFLE_PARTITIONS = "spark.sql.shuffle.partitions";
+  public static final String FS_S3A_CONNECTION_MAXIMUM = "fs.s3a.connection.maximum";
 }

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataSqlZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataSqlZeppelinInterpreter.java
@@ -88,6 +88,7 @@ public class SnappyDataSqlZeppelinInterpreter extends Interpreter {
   public void open() {
     if (null != SnappyContext.globalSparkContext()) {
       sc = SnappyContext.globalSparkContext();
+      sc.hadoopConfiguration().set(Constants.FS_S3A_CONNECTION_MAXIMUM,"1000");
     }
     this.maxResult = Integer.parseInt(getProperty("zeppelin.spark.maxResult"));
 
@@ -95,6 +96,10 @@ public class SnappyDataSqlZeppelinInterpreter extends Interpreter {
       sc.hadoopConfiguration().set(Constants.FS_S3A_IMPL, "org.apache.hadoop.fs.s3a.S3AFileSystem");
       sc.hadoopConfiguration().set(Constants.FS_S3A_ACCESS_KEY, getProperty(Constants.FS_S3A_ACCESS_KEY));
       sc.hadoopConfiguration().set(Constants.FS_S3A_SECRET_KEY, getProperty(Constants.FS_S3A_SECRET_KEY));
+      if (null != getProperty(Constants.FS_S3A_CONNECTION_MAXIMUM)) {
+        sc.hadoopConfiguration().set(Constants.FS_S3A_CONNECTION_MAXIMUM,
+                getProperty(Constants.FS_S3A_CONNECTION_MAXIMUM));
+      }
     }
 
     paragraphContextCache = CacheBuilder.newBuilder()


### PR DESCRIPTION
## Changes proposed in this pull request
- Setting default maximum connection for s3 to 1000
## Patch testing
- Manually tested 
## Other PRs

No

…00 and allow user to specify that property in interpreter setting
