### PR TITLE
passing credentials to snappycontext

### DIFF
--- a/src/main/java/org/apache/zeppelin/interpreter/Constants.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/Constants.java
@@ -23,4 +23,8 @@ public class Constants {
   public static final String FS_S3A_IMPL = "fs.s3a.impl";
   public static final String SPARK_SQL_SHUFFLE_PARTITIONS = "spark.sql.shuffle.partitions";
   public static final String FS_S3A_CONNECTION_MAXIMUM = "fs.s3a.connection.maximum";
+  public static final String DEFAULT_USER_KEY = "default.user";
+  public static final String DEFAULT_USER_PASSWORD = "default.password";
+  public static final String USER_KEY = "user";
+  public static final String USER_PASSWORD = "password";
 }

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataSqlZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataSqlZeppelinInterpreter.java
@@ -104,10 +104,17 @@ public class SnappyDataSqlZeppelinInterpreter extends Interpreter {
       }
     }
 
+
    // long end,start;
     for(int i=0;i<50;i++) {
       //start = System.currentTimeMillis();
       SnappyContext snc = new SnappyContext(sc);
+      if (null != getProperty(Constants.DEFAULT_USER_KEY) ) {
+        snc.setConf(Constants.USER_KEY, getProperty(Constants.DEFAULT_USER_KEY));
+        if (null != getProperty(Constants.DEFAULT_USER_PASSWORD) ) {
+          snc.setConf(Constants.USER_PASSWORD, getProperty(Constants.DEFAULT_USER_PASSWORD));
+        }
+      }
       //end = System.currentTimeMillis();
       snc.tables().collect();
       connectionQueue.add(snc);

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -225,6 +225,12 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   public SnappyContext getSnappyContext() {
     synchronized (sharedInterpreterLock) {
       SnappyContext snc = new SnappyContext(getSparkContext());
+      if (null != getProperty(Constants.DEFAULT_USER_KEY) ) {
+        snc.setConf(Constants.USER_KEY, getProperty(Constants.DEFAULT_USER_KEY));
+        if (null != getProperty(Constants.DEFAULT_USER_PASSWORD) ) {
+          snc.setConf(Constants.USER_PASSWORD, getProperty(Constants.DEFAULT_USER_PASSWORD));
+        }
+      }
       return snc;
     }
   }


### PR DESCRIPTION
The security credentials from props with keys default.user & default.password are now set in the snappycontext being created.