### PR TITLE
Snap 3113: resuming interpreter after critical hit

### DIFF
--- a/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
@@ -26,11 +26,14 @@ public class MemoryListenerImpl implements ResourceListener<MemoryEvent> {
 
   @Override
   public void onEvent(MemoryEvent event) {
-
-    logger.warn("Critical Up memory event Occured");
-
     if (event.getState().isCritical()) {
+      logger.warn("Critical Up memory event occured");
       SnappyDataZeppelinInterpreter.cancelAllJobsAndPause();
+    } else if (event.getState().isNormal()) {
+      logger.info("Memory event is now normal");
+      SnappyDataZeppelinInterpreter.resume();
+    } else {
+      logger.info("Memory event state: " + event.getState() + " occured. Taking no action");
     }
   }
 }

--- a/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
@@ -29,11 +29,9 @@ public class MemoryListenerImpl implements ResourceListener<MemoryEvent> {
     if (event.getState().isCritical()) {
       logger.warn("Critical Up memory event occured");
       SnappyDataZeppelinInterpreter.cancelAllJobsAndPause();
-    } else if (event.getState().isNormal()) {
+    } else {
       logger.info("Memory event is now normal");
       SnappyDataZeppelinInterpreter.resume();
-    } else {
-      logger.info("Memory event state: " + event.getState() + " occured. Taking no action");
     }
   }
 }

--- a/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/MemoryListenerImpl.java
@@ -30,7 +30,6 @@ public class MemoryListenerImpl implements ResourceListener<MemoryEvent> {
       logger.warn("Critical Up memory event occured");
       SnappyDataZeppelinInterpreter.cancelAllJobsAndPause();
     } else {
-      logger.info("Memory event is now normal");
       SnappyDataZeppelinInterpreter.resume();
     }
   }

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -704,10 +704,13 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   public InterpreterResult interpret(String line, InterpreterContext context) {
 
     InterpreterResult result=null;
-    if (!pauseInterpreter) {
+    if (pauseInterpreter) {
+      result = new InterpreterResult(Code.INCOMPLETE,
+          "Memory threshold reached.Please restart interpreter to release memory");
+    } else {
       if (sparkVersion.isUnsupportedVersion()) {
         result = new InterpreterResult(Code.ERROR, "Spark " + sparkVersion.toString()
-                + " is not supported");
+            + " is not supported");
       }
 
       z.setInterpreterContext(context);
@@ -715,9 +718,6 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
         result = new InterpreterResult(Code.SUCCESS);
       }
       result = interpret(line.split("\n"), context);
-    } else {
-      result = new InterpreterResult(Code.INCOMPLETE,
-              "Memory threshold reached.Please restart interpreter to release memory");
     }
     /*
     Resetting the classloader due to this issue: https://issues.scala-lang.org/browse/SI-8521
@@ -1019,5 +1019,10 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
     logger.info("Pausing interpreter and cancelling all Jobs.");
     pauseInterpreter = true;
     sc.cancelAllJobs();
+  }
+
+  public static void resume() {
+    logger.info("Resuming interpreter.");
+    pauseInterpreter = false;
   }
 }

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -1022,7 +1022,9 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
   }
 
   public static void resume() {
-    logger.info("Resuming interpreter.");
+    if (pauseInterpreter) {
+      logger.info("Resuming interpreter.");
+    }
     pauseInterpreter = false;
   }
 }

--- a/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/interpreter/SnappyDataZeppelinInterpreter.java
@@ -1023,8 +1023,8 @@ public class SnappyDataZeppelinInterpreter extends Interpreter {
 
   public static void resume() {
     if (pauseInterpreter) {
-      logger.info("Resuming interpreter.");
+      logger.info("Memory event state no longer critical. Resuming interpreter.");
+      pauseInterpreter = false;
     }
-    pauseInterpreter = false;
   }
 }


### PR DESCRIPTION
Avoiding excess logging